### PR TITLE
[DRAFT, NEEDS DESIGN REVIEW] feat core: BooleanFunctionModel, TruthTableModel, DontCare

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ For private and protected objects docstrings are encouraged but not obligatory.
 4. All Python modules should include `__all__` definition, to avoid occasional
 export of unwanted objects (e.g. export of imported objects).
 5. Import of "all" objects (`from x import *`) must not be used.
+6. All standard libraries should be imported as packages
+(e.g. `import itertools`).
+7. For package `typing` shortening `tp` should be used (`import typing as tp`).
 
 ## Formatters
 

--- a/boolean_circuit_tool/core/boolean_function.py
+++ b/boolean_circuit_tool/core/boolean_function.py
@@ -1,13 +1,32 @@
 import abc
 import typing as tp
 
-__all__ = ['BooleanFunction']
+import typing_extensions as tp_ext
+
+from boolean_circuit_tool.core.exceptions import BadDefinitionError
+
+
+__all__ = [
+    'BooleanFunctionModel',
+    'BooleanFunction',
+]
+
+from boolean_circuit_tool.core.logic import TriValue
+
+
+BooleanFunctionT = tp.TypeVar('BooleanFunctionT', covariant=True)
 
 
 @tp.runtime_checkable
-class BooleanFunction(tp.Protocol):
-    """Protocol for any object that behaves like boolean function, e.g. Circuit,
-    TruthTable or PythonFunction."""
+class BooleanFunctionModel(tp.Protocol[BooleanFunctionT]):
+    """
+    Protocol for any object that describes model of boolean function, meaning that it
+    defines subset of rules which must be satisfied by searched boolean function.
+
+    Outputs of model can be either `bool`, or `DontCare` object, which
+    means that output value is not fixed yet, and should be defined.
+
+    """
 
     @property
     @abc.abstractmethod
@@ -22,6 +41,61 @@ class BooleanFunction(tp.Protocol):
         """
         :return: number of outputs.
         """
+
+    def check(self, inputs: list[bool]) -> tp.Sequence[TriValue]:
+        """
+        Get model output values that correspond to provided `inputs`.
+
+        :param inputs: values of input gates.
+        :return: value of outputs evaluated for input values `inputs`.
+
+        """
+
+    def check_at(self, inputs: list[bool], output_index: int) -> TriValue:
+        """
+        Get model value of `output_index`th output that corresponds to provided
+        `inputs`.
+
+        :param inputs: values of input gates.
+        :param output_index: index of desired output.
+        :return: value of `output_index` evaluated for input values `inputs`.
+
+        """
+
+    def get_model_truth_table(self) -> tp.Sequence[tp.Sequence[TriValue]]:
+        """
+        Get truth table of a boolean function, which is a matrix, `i`th row of which
+        contains values of `i`th output, which may contain bool or DontCare values, and
+        `j`th column corresponds to the input which is a binary encoding of a number `j`
+        (for example j=9 corresponds to [..., 1, 0, 0, 1])
+
+        :return: truth table describing this model.
+
+        """
+
+    def define(
+        self,
+        definition: tp.Mapping[tuple[tuple[bool, ...], int], bool],
+    ) -> BooleanFunctionT:
+        """
+        Defines this model by defining ambiguous output values.
+
+        :param definition: mapping of pairs (input value set, output index) to
+        output values, required to completely define this boolean function model.
+        :return: new object of `BooleanFunctionT` type.
+
+        """
+
+
+@tp.runtime_checkable
+class BooleanFunction(BooleanFunctionModel, tp.Protocol):
+    """
+    Protocol for any object that behaves like boolean function, e.g. Circuit, TruthTable
+    or PythonFunction.
+
+    Any `BooleanFunction` is also a completely defined `BooleanFunctionModel`.
+
+    """
 
     def evaluate(self, inputs: list[bool]) -> list[bool]:
         """
@@ -166,7 +240,7 @@ class BooleanFunction(tp.Protocol):
 
         """
 
-    def get_truth_table(self) -> list[list[bool]]:
+    def get_truth_table(self) -> tp.Sequence[tp.Sequence[bool]]:
         """
         Get truth table of a boolean function, which is a matrix, `i`th row of which
         contains values of `i`th output, and `j`th column corresponds to the input which
@@ -176,3 +250,52 @@ class BooleanFunction(tp.Protocol):
         :return: truth table describing this function.
 
         """
+
+    def check(self, inputs: list[bool]) -> tp.Sequence[TriValue]:
+        """
+        Get model output values that correspond to provided `inputs`.
+
+        :param inputs: values of input gates.
+        :return: value of outputs evaluated for input values `inputs`.
+
+        """
+        return self.evaluate(inputs=inputs)
+
+    def check_at(self, inputs: list[bool], output_index: int) -> TriValue:
+        """
+        Get model value of `output_index`th output that corresponds to provided
+        `inputs`.
+
+        :param inputs: values of input gates.
+        :param output_index: index of desired output.
+        :return: value of `output_index` evaluated for input values `inputs`.
+
+        """
+        return self.evaluate_at(inputs=inputs, output_index=output_index)
+
+    def get_model_truth_table(self) -> tp.Sequence[tp.Sequence[TriValue]]:
+        """
+        Get truth table of a boolean function, which is a matrix, `i`th row of which
+        contains values of `i`th output, which may contain bool or DontCare values, and
+        `j`th column corresponds to the input which is a binary encoding of a number `j`
+        (for example j=9 corresponds to [..., 1, 0, 0, 1])
+
+        :return: truth table describing this model.
+
+        """
+        return self.get_truth_table()
+
+    def define(
+        self, definition: tp.Mapping[tuple[tuple[bool, ...], int], bool]
+    ) -> tp_ext.Self:
+        """
+        Defines this model by defining ambiguous output values.
+
+        :param definition: mapping of pairs (input value set, output index) to
+        output values, required to completely define this boolean function model.
+        :return: new object of `BooleanFunctionT` type.
+
+        """
+        if definition:
+            raise BadDefinitionError("Boolean function is already defined.")
+        return self

--- a/boolean_circuit_tool/core/circuit/circuit.py
+++ b/boolean_circuit_tool/core/circuit/circuit.py
@@ -313,12 +313,12 @@ class Circuit:
     def __str__(self):
         input_str = textwrap.shorten(
             'INPUTS: ' + '; '.join(f'{input_label}' for input_label in self._inputs),
-            wigth=100,
+            width=100,
         )
         output_str = textwrap.shorten(
             'OUTPUTS: '
             + '; '.join(f'{output_label}' for output_label in self._outputs),
-            wigth=100,
+            width=100,
         )
         return f"{self.__class__.__name__}\n\t{input_str}\n\t{output_str}"
 

--- a/boolean_circuit_tool/core/circuit/operators.py
+++ b/boolean_circuit_tool/core/circuit/operators.py
@@ -44,7 +44,7 @@ class _Undefined:
         return isinstance(rhs, _Undefined)
 
     def __hash__(self):
-        return hash('Undefined')
+        return hash(self.__class__.__name__)
 
 
 # To be similar to False and True.

--- a/boolean_circuit_tool/core/exceptions.py
+++ b/boolean_circuit_tool/core/exceptions.py
@@ -1,0 +1,27 @@
+"""Module defines exceptions related to core objects, e.g. Circuit."""
+
+from boolean_circuit_tool.exceptions import BooleanCircuitToolError
+
+__all__ = [
+    'BooleanModelError',
+    'BooleanFunctionError',
+    'BadDefinitionError',
+]
+
+
+class BooleanModelError(BooleanCircuitToolError):
+    """Base for BooleanFunctionModel protocol general class of exceptions."""
+
+    pass
+
+
+class BooleanFunctionError(BooleanCircuitToolError):
+    """Base for BooleanFunction protocol general class of exceptions."""
+
+    pass
+
+
+class BadDefinitionError(BooleanModelError):
+    """Represents error raised when boolean model is given a bad definition."""
+
+    pass

--- a/boolean_circuit_tool/core/logic.py
+++ b/boolean_circuit_tool/core/logic.py
@@ -1,0 +1,35 @@
+import typing as tp
+
+from boolean_circuit_tool.core.exceptions import BooleanModelError
+
+
+__all__ = [
+    'DontCareCastError',
+    'DontCare',
+    'TriValue',
+]
+
+
+class DontCareCastError(BooleanModelError):
+    """Represents error raised when `DontCare` is being cast to bool."""
+
+    pass
+
+
+class _DontCare:
+    def __bool__(self):
+        raise DontCareCastError("Bool can't be created from DontCare.")
+
+    def __eq__(self, rhs):
+        return isinstance(rhs, _DontCare)
+
+    def __hash__(self):
+        return hash(self.__class__.__name__)
+
+
+# To be similar to False and True.
+# Represents indeterminate state (of output) which can
+# be either False or True depending on condition definition.
+DontCare = _DontCare()
+
+TriValue = tp.Union[bool, _DontCare]

--- a/boolean_circuit_tool/core/parser/bench.py
+++ b/boolean_circuit_tool/core/parser/bench.py
@@ -52,7 +52,7 @@ class AbstractBenchParser(AbstractParser, metaclass=abc.ABCMeta):
     def __init__(self, *args, **kwargs):
         super(AbstractBenchParser, self).__init__(*args, **kwargs)
         # Dict of specific processing methods for gates
-        self._processings: dict[str, tp.Callable] = {
+        self._processings: dict[str, tp.Callable[..., tp.Iterable]] = {
             NOT.name: self._process_not,
             AND.name: self._process_and,
             NAND.name: self._process_nand,

--- a/boolean_circuit_tool/core/truth_table.py
+++ b/boolean_circuit_tool/core/truth_table.py
@@ -1,14 +1,22 @@
+import copy
 import itertools
 import math
 import typing as tp
 
-from boolean_circuit_tool.core.boolean_function import BooleanFunction
+from boolean_circuit_tool.core.boolean_function import (
+    BooleanFunction,
+    BooleanFunctionModel,
+)
+from boolean_circuit_tool.core.logic import TriValue
 
 
-__all__ = ['TruthTable']
+__all__ = [
+    'TruthTableModel',
+    'TruthTable',
+]
 
 
-def values_to_index(inputs: list[bool]) -> int:
+def values_to_index(inputs: tp.Iterable[bool]) -> int:
     """
     Get index by input value set.
 
@@ -27,6 +35,102 @@ def get_bit_value(value: int, bit_idx: int) -> bool:
     return bool((value & (1 << bit_idx)) >> bit_idx)
 
 
+class TruthTableModel(BooleanFunctionModel):
+    """Boolean function model given as a truth table with don't care outputs."""
+
+    def __init__(self, table: list[list[TriValue]]):
+        """
+        :param table: truth table given as a list of lists of bools. `i`th list
+        is a truth table for output number `i`, trimmed to contain only output
+        values. Element `j` of list `i` is value for output `i` for input which
+        is a binary encoding of a number `j` (e.g. 9 -> [..., 1, 0, 0, 1]).
+
+        """
+        log = math.log2(len(table[0]))
+        if not log.is_integer():
+            raise ValueError(
+                "TruthTableModel got truth table with number "
+                "of rows not equal to a power of two."
+            )
+
+        self._input_size = int(log)
+        self._output_size = len(table)
+        self._table: list[list[TriValue]] = table
+        # Transposed truth table, element (i, j) of which is a value
+        # of the output `j` when evaluated at input number `i`.
+        self._table_t: list[list[TriValue]] = [list(i) for i in zip(*table)]
+
+    @property
+    def input_size(self) -> int:
+        """
+        :return: number of inputs.
+        """
+        return self._input_size
+
+    @property
+    def output_size(self) -> int:
+        """
+        :return: number of outputs.
+        """
+        return self._output_size
+
+    def check(self, inputs: list[bool]) -> tp.Sequence[TriValue]:
+        """
+        Get model output values that correspond to provided `inputs`.
+
+        :param inputs: values of input gates.
+        :return: value of outputs evaluated for input values `inputs`.
+
+        """
+        idx = values_to_index(inputs)
+        return self._table_t[idx]
+
+    def check_at(self, inputs: list[bool], output_index: int) -> TriValue:
+        """
+        Get model value of `output_index`th output that corresponds to provided
+        `inputs`.
+
+        :param inputs: values of input gates.
+        :param output_index: index of desired output.
+        :return: value of `output_index` evaluated for input values `inputs`.
+
+        """
+        idx = values_to_index(inputs)
+        return self._table_t[idx][output_index]
+
+    def get_model_truth_table(self) -> tp.Sequence[tp.Sequence[TriValue]]:
+        """
+        Get truth table of a boolean function, which is a matrix, `i`th row of which
+        contains values of `i`th output, which may contain bool or DontCare values, and
+        `j`th column corresponds to the input which is a binary encoding of a number `j`
+        (for example j=9 corresponds to [..., 1, 0, 0, 1])
+
+        :return: truth table describing this model.
+
+        """
+        return self._table
+
+    def define(
+        self,
+        definition: tp.Mapping[tuple[tuple[bool, ...], int], bool],
+    ) -> 'TruthTable':
+        """
+        Defines this model by defining ambiguous output values.
+
+        :param definition: mapping of pairs (input value set, output index) to
+        output values, required to completely define this boolean function model.
+        :return: new object of `BooleanFunctionT` type.
+
+        """
+        _table_cp = copy.deepcopy(self._table)
+        for (input_value, output_idx), output_value in definition.items():
+            _table_cp[output_idx][values_to_index(input_value)] = output_value
+
+        return TruthTable(
+            table=tp.cast(list[list[bool]], _table_cp),
+        )
+
+
 class TruthTable(BooleanFunction):
     """Boolean function given as a truth table."""
 
@@ -38,18 +142,20 @@ class TruthTable(BooleanFunction):
         is a binary encoding of a number `j` (e.g. 9 -> [..., 1, 0, 0, 1]).
 
         """
-        self._output_size = len(table)
         log = math.log2(len(table[0]))
         if not log.is_integer():
             raise ValueError(
                 "TruthTable got truth table with number "
                 "of rows not equal to a power of two."
             )
+
         self._input_size = int(log)
-        self._table = table
+        self._output_size = len(table)
+
+        self._table: list[list[bool]] = table
         # Transposed truth table, element (i, j) of which is a value
         # of the output `j` when evaluated at input number `i`.
-        self._table_t = [list(i) for i in zip(*table)]
+        self._table_t: list[list[bool]] = [list(i) for i in zip(*table)]
 
     @property
     def input_size(self) -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,5 +86,12 @@ blank = true
 recursive = true
 pre-summary-newline = true
 
+[tool.mypy]
+python_version = "3.9"
+warn_return_any = true
+warn_unused_configs = true
+check_untyped_defs = true
+
 [[tool.mypy.overrides]]
+module = ''
 ignore_missing_imports = true

--- a/tests/core/logic_test.py
+++ b/tests/core/logic_test.py
@@ -1,0 +1,8 @@
+import pytest
+
+from boolean_circuit_tool.core.logic import DontCare, DontCareCastError
+
+
+def test_dont_care_raises_when_casted_to_bool():
+    with pytest.raises(DontCareCastError):
+        _ = bool(DontCare)

--- a/tests/core/truth_table_test.py
+++ b/tests/core/truth_table_test.py
@@ -3,7 +3,8 @@ import typing as tp
 
 import pytest
 
-from boolean_circuit_tool.core.truth_table import TruthTable
+from boolean_circuit_tool.core.logic import DontCare
+from boolean_circuit_tool.core.truth_table import TruthTable, TruthTableModel
 
 
 def generate_random_truth_table(input_size: int, output_size: int) -> list[list[bool]]:
@@ -101,3 +102,83 @@ def test_is_out_symmetric():
     neg = truth_table.get_symmetric_and_negations_of([0])
     assert neg is not None
     assert neg == negations
+
+
+class TestTruthTableModel:
+    simple_model = TruthTableModel(
+        table=[[False, DontCare, True, DontCare]],
+    )
+    two_output_model = TruthTableModel(
+        table=[
+            [True, True, DontCare, DontCare],
+            [DontCare, False, True, False],
+        ],
+    )
+
+    def test_model_shape(self):
+        assert self.simple_model.input_size == 2
+        assert self.simple_model.output_size == 1
+        assert self.two_output_model.input_size == 2
+        assert self.two_output_model.output_size == 2
+
+    def test_model_checks(self):
+        assert self.simple_model.check([True, False]) == [True]
+        assert self.simple_model.check([True, True]) == [DontCare]
+        assert self.simple_model.check_at([True, True], 0) == DontCare
+
+        assert self.two_output_model.check([False, False]) == [True, DontCare]
+        assert self.two_output_model.check_at([False, False], 1) == DontCare
+
+    @pytest.mark.parametrize(
+        'model, expected',
+        [
+            pytest.param(
+                simple_model,
+                [[False, DontCare, True, DontCare]],
+                id='simple model',
+            ),
+            pytest.param(
+                two_output_model,
+                [
+                    [True, True, DontCare, DontCare],
+                    [DontCare, False, True, False],
+                ],
+                id='two output model',
+            ),
+        ],
+    )
+    def test_get_model_truth_table(self, model: TruthTableModel, expected: list):
+        assert model.get_model_truth_table() == expected
+
+    @pytest.mark.parametrize(
+        'model, definition, expected',
+        [
+            pytest.param(
+                simple_model,
+                {
+                    ((False, True), 0): True,
+                    ((True, True), 0): False,
+                },
+                [[False, True, True, False]],
+                id='simple model',
+            ),
+            pytest.param(
+                two_output_model,
+                {
+                    ((True, False), 0): False,
+                    ((True, True), 0): True,
+                    ((False, False), 1): False,
+                },
+                [
+                    [True, True, False, True],
+                    [False, False, True, False],
+                ],
+                id='two output model',
+            ),
+        ],
+    )
+    def test_model_defines(
+        self, model: TruthTableModel, definition: dict, expected: list
+    ):
+        tt = model.define(definition=definition)
+        assert tt.get_truth_table() == expected


### PR DESCRIPTION
Changelog:

- Added `BooleanFunctionModel` protocol. It will describe any not-completely defined boolean function (e.g. containing DontCares as outputs).
- Added `TruthTableModel` (`BooleanFunctionModel` implementation for `TruthTable`).
- Added separate `DontCare` object.
- `BooleanFunction` now inherits `BooleanFunctionModel` and default-defines its methods (since it is actually special case of a model, which has only one solution).
- Set up mypy to be more thorough.
- minor fixes.
